### PR TITLE
feat: apply sort of penalty theory in heyawake solver

### DIFF
--- a/solver/core/const.py
+++ b/solver/core/const.py
@@ -276,8 +276,20 @@ PUZZLE_TYPES: Dict[str, Dict[str, Any]] = {
                 "url": "https://puzz.link/p?heyawake/19/15/201480mhg2i40a8s192816704r503gk0m2g2oa0a18085010k046g0003hu0104000400fbvgvo005fu1800o0000000800600000003s0003c-1c140411g81ah8233",
                 "config": {"fast_mode": True},
             },
+            {
+                "url": "https://puzz.link/p?heyawake/8/7/060o00000081g2000000-121g",
+                "config": {"fast_mode": True, "limit_border": 1},
+            },
+            {
+                "url": "https://puzz.link/p?heyawake/12/12/00000o0003063cc0o00030000000008020080a4a92a02008020000-2811111111",
+                "config": {"fast_mode": True, "limit_2x2": 1},
+            },
         ],
-        "parameters": {"fast_mode": {"name": "Fast Mode", "type": "checkbox", "default": False}},
+        "parameters": {
+            "fast_mode": {"name": "Fast Mode", "type": "checkbox", "default": False},
+            "limit_border": {"name": "Border Limit", "type": "number", "default": 0},
+            "limit_2x2": {"name": "2x2 Limit", "type": "number", "default": 0},
+        },
     },
     "hitori": {
         "name": "Hitori",

--- a/solver/core/solution.py
+++ b/solver/core/solution.py
@@ -90,7 +90,8 @@ class ClingoSolver:
 
     def add_program_line(self, line: str):
         """Add a line to the program."""
-        self.program += line + "\n"
+        if line != "":
+            self.program += line + "\n"
 
     def reset(self):
         """Reset the program."""

--- a/solver/heyawake.py
+++ b/solver/heyawake.py
@@ -56,7 +56,7 @@ def calculate_penalty(_id: int, ar: Iterable[Tuple[int, int]], puzzle: Puzzle) -
         i, segment_border_penalty = 0, 0
         while i < cols:
             segment = 0
-            while (r, i) in ar and i < cols:
+            while (r, i) in ar and i < cols and puzzle.surface.get((r, i)) != 2:
                 segment += 1
                 i += 1
 
@@ -66,7 +66,7 @@ def calculate_penalty(_id: int, ar: Iterable[Tuple[int, int]], puzzle: Puzzle) -
         i = 0
         while i < rows:
             segment = 0
-            while (i, c) in ar and i < cols:
+            while (i, c) in ar and i < cols and puzzle.surface.get((i, c)) != 2:
                 segment += 1
                 i += 1
 
@@ -88,6 +88,13 @@ def calculate_penalty(_id: int, ar: Iterable[Tuple[int, int]], puzzle: Puzzle) -
 
         if plus_segment and r + 1 < rows and c + 1 < cols:
             loop_penalty += 1
+
+        cost_plus_segment = True
+        for dr, dc in ((0, 0), (0, 1), (1, 0), (1, 1)):
+            r1, c1 = r + dr, c + dc
+            cost_plus_segment &= puzzle.surface.get((r1, c1)) == 2
+        if cost_plus_segment:  # remove known 2x2 regions
+            loop_penalty -= 1
 
         internal_loop = False
         if (r, c) not in ar and puzzle.surface.get((r, c)) in [1, 3, 4, 8]:  # internal cell is shaded
@@ -141,7 +148,7 @@ def solve(puzzle: Puzzle) -> List[Solution]:
         solver.add_program_line(area(_id=i, src_cells=ar))
         calculate_penalty(_id=i, ar=ar, puzzle=puzzle)
 
-        print("Area", i, "has total shaded of", puzzle.text[rc] if rc else "N/A")
+        print("Area", i, "has cost penalty of", puzzle.text[rc] * 3 if rc else "N/A")
 
         if rc:
             data = puzzle.text[rc]

--- a/solver/heyawake.py
+++ b/solver/heyawake.py
@@ -113,13 +113,15 @@ def solve(puzzle: Puzzle) -> List[Solution]:
             solver.add_program_line(count(data, color="gray", _type="area", _id=i))
 
             if puzzle.param["fast_mode"] and data > len(ar) // 4:
+                lmt_2x2 = int(puzzle.param["limit_2x2"])
+                lmt_border = int(puzzle.param["limit_border"])
                 solver.add_program_line(area_border(_id=i, ar=ar))
                 solver.add_program_line(area_border_connected(_id=i, color="gray", adj_type="x"))
-                solver.add_program_line(limit_area_2x2_rect(limit=1, _id=i, color="gray"))
-                solver.add_program_line(limit_border(limit=1, ar=ar, puzzle=puzzle, _type="top", color="gray"))
-                solver.add_program_line(limit_border(limit=1, ar=ar, puzzle=puzzle, _type="bottom", color="gray"))
-                solver.add_program_line(limit_border(limit=1, ar=ar, puzzle=puzzle, _type="left", color="gray"))
-                solver.add_program_line(limit_border(limit=1, ar=ar, puzzle=puzzle, _type="right", color="gray"))
+                solver.add_program_line(limit_area_2x2_rect(lmt_2x2, _id=i, color="gray"))
+                solver.add_program_line(limit_border(lmt_border, ar, puzzle, _type="top", color="gray"))
+                solver.add_program_line(limit_border(lmt_border, ar, puzzle, _type="bottom", color="gray"))
+                solver.add_program_line(limit_border(lmt_border, ar, puzzle, _type="left", color="gray"))
+                solver.add_program_line(limit_border(lmt_border, ar, puzzle, _type="right", color="gray"))
 
     for (r, c), color_code in puzzle.surface.items():
         if color_code in [1, 3, 4, 8]:  # shaded color (DG, GR, LG, BK)

--- a/solver/heyawake.py
+++ b/solver/heyawake.py
@@ -1,5 +1,6 @@
 """The Heyawake solver."""
 
+import itertools
 from typing import Iterable, List, Tuple, Union
 
 from .core.common import area, count, display, grid, shade_c
@@ -28,6 +29,12 @@ def avoid_area_2x2_rect(_id: int, color: str = "black") -> str:
     return rule
 
 
+def avoid_area_isolated_inner_cell(_id: int, color: str = "black") -> str:
+    """Avoid isolated non-border cells in areas."""
+    rule = f":- area({_id}, R, C), area({_id}, R - 1, C - 1), area({_id}, R - 1, C + 1), area({_id}, R + 1, C - 1), area({_id}, R + 1, C + 1), {color}(R, C), not {color}(R - 1, C - 1), not {color}(R - 1, C + 1), not {color}(R + 1, C - 1), not {color}(R + 1, C + 1).\n"
+    return rule
+
+
 def area_border(_id: int, ar: Iterable[Tuple[int, int]]) -> str:
     """Generates a fact for the border of an area."""
     borders = set()
@@ -36,8 +43,59 @@ def area_border(_id: int, ar: Iterable[Tuple[int, int]]) -> str:
             r1, c1 = r + dr, c + dc
             if (r1, c1) not in ar:
                 borders.add((r, c))
+
     rule = "\n".join(f"area_border({_id}, {r}, {c})." for r, c in borders)
     return rule
+
+
+def calculate_penalty(_id: int, ar: Iterable[Tuple[int, int]], puzzle: Puzzle) -> int:
+    """Calculate penalties of an area."""
+    rows, cols = puzzle.row, puzzle.col
+
+    def calculate_each_border_penalty(r: int = 0, c: int = 0) -> int:
+        i, segment_border_penalty = 0, 0
+        while i < cols:
+            segment = 0
+            while (r, i) in ar and i < cols:
+                segment += 1
+                i += 1
+
+            segment_border_penalty += (segment + 1) // 2
+            i += 1
+
+        i = 0
+        while i < rows:
+            segment = 0
+            while (i, c) in ar and i < cols:
+                segment += 1
+                i += 1
+
+            segment_border_penalty += (segment + 1) // 2
+            i += 1
+
+        return segment_border_penalty
+
+    loop_penalty = 0
+    for r, c in itertools.product(range(rows), range(cols)):
+        plus_segment = 0
+        for dr, dc in ((0, 0), (0, 1), (1, 0), (1, 1)):
+            r1, c1 = r + dr, c + dc
+            if (r1, c1) not in ar and puzzle.surface.get((r1, c1)) in [1, 3, 4, 8]:
+                plus_segment = 0
+                break
+
+            plus_segment += (r1, c1) in ar
+
+        if plus_segment >= 2 and r + 1 < rows and c + 1 < cols:
+            loop_penalty += 1
+
+    border_penalty = 0
+    border_penalty += calculate_each_border_penalty(0, 0)
+    border_penalty += calculate_each_border_penalty(rows - 1, cols - 1)
+
+    print("Area", _id, "has total penalty of", loop_penalty + border_penalty)
+
+    return loop_penalty + border_penalty
 
 
 def area_border_connected(_id: int, color: str = "black", adj_type: Union[int, str] = 4) -> str:
@@ -70,6 +128,9 @@ def solve(puzzle: Puzzle) -> List[Solution]:
     areas = full_bfs(puzzle.row, puzzle.col, puzzle.edge, puzzle.text)
     for i, (ar, rc) in enumerate(areas.items()):
         solver.add_program_line(area(_id=i, src_cells=ar))
+        calculate_penalty(_id=i, ar=ar, puzzle=puzzle)
+
+        print("Area", i, "has total shaded of", puzzle.text[rc] if rc else "N/A")
 
         if rc:
             data = puzzle.text[rc]
@@ -78,6 +139,7 @@ def solve(puzzle: Puzzle) -> List[Solution]:
 
             if puzzle.param["fast_mode"] and data > len(ar) // 4:
                 solver.add_program_line(avoid_area_2x2_rect(_id=i, color="gray"))
+                solver.add_program_line(avoid_area_isolated_inner_cell(_id=i, color="gray"))
                 solver.add_program_line(area_border(_id=i, ar=ar))
                 solver.add_program_line(area_border_connected(_id=i, color="gray", adj_type="x"))
 

--- a/solver/heyawake.py
+++ b/solver/heyawake.py
@@ -77,23 +77,34 @@ def calculate_penalty(_id: int, ar: Iterable[Tuple[int, int]], puzzle: Puzzle) -
 
     loop_penalty = 0
     for r, c in itertools.product(range(rows), range(cols)):
-        plus_segment = 0
+        plus_segment = False
         for dr, dc in ((0, 0), (0, 1), (1, 0), (1, 1)):
             r1, c1 = r + dr, c + dc
             if (r1, c1) not in ar and puzzle.surface.get((r1, c1)) in [1, 3, 4, 8]:
-                plus_segment = 0
+                plus_segment = False
                 break
 
-            plus_segment += (r1, c1) in ar
+            plus_segment |= (r1, c1) in ar
 
-        if plus_segment >= 2 and r + 1 < rows and c + 1 < cols:
+        if plus_segment and r + 1 < rows and c + 1 < cols:
             loop_penalty += 1
+
+        internal_loop = False
+        if (r, c) not in ar and puzzle.surface.get((r, c)) in [1, 3, 4, 8]:  # internal cell is shaded
+            internal_loop = True
+            for dr, dc in ((0, 1), (1, 0), (0, -1), (-1, 0), (1, 1), (1, -1), (-1, 1), (-1, -1)):
+                if (r + dr, c + dc) not in ar:  # internal cell is not in the area, but surrounding cells in the area
+                    internal_loop = False
+                    break
+
+        if internal_loop:
+            loop_penalty += 1  # calculate internal loops
 
     border_penalty = 0
     border_penalty += calculate_each_border_penalty(0, 0)
     border_penalty += calculate_each_border_penalty(rows - 1, cols - 1)
 
-    print("Area", _id, "has total penalty of", loop_penalty + border_penalty)
+    print("Area", _id, "has total penalty of", loop_penalty, "+", border_penalty)
 
     return loop_penalty + border_penalty
 

--- a/static/app.js
+++ b/static/app.js
@@ -52,6 +52,9 @@ function make_param(id, type, name, value) {
     paramInput.className = "param_input";
     paramInput.id = `param_${id}`;
 
+    if (type === "number") {
+      paramInput.min = 0;
+    }
     if (type === "checkbox") paramInput.checked = value;
     else paramInput.value = value;
   } else {
@@ -80,7 +83,6 @@ $(document).ready(function () {
   const solveButton = document.getElementById("solve");
   const resetButton = document.getElementById("solver_reset");
   const parameterBox = document.getElementById("parameter_box");
-  const updateDisplay = document.getElementById("closeBtn_nb2");
 
   const categoryName = {
     shade: "- Shading -",


### PR DESCRIPTION
It's not very easy to apply the full penalty theory in heyawake, because the loop detection would be impossible. 

However, we are still able to implement some insights of penalty theory here. For the area that shaded cells are greater than a quarter of the cells in this area, the following conditions are set:
- limited `2x2` unshaded cells in this area (can be adjusted)
- possibly `maximize` shaded cells in the border  (can be adjusted)
- shaded cells are connected diagonally to the border of this area

From these rules, a large set of heyawake puzzles can be solved now, what are very hard to solve (without manual initial conditions) is:
- very large clue
- area not connected to the puzzle border
- some intended puzzles for the extra conditions

Hope this merge will make the heyawake solver faster a bit.