### PR TITLE
chore: bump version 0.5.1 -> 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "noqx"
-version = "0.5.1"
+version = "0.6.0"
 description = "Extended logic puzzle solver of Noq."
 authors = [
   {name = "Yaoyu Zhu"},

--- a/uv.lock
+++ b/uv.lock
@@ -801,7 +801,7 @@ wheels = [
 
 [[package]]
 name = "noqx"
-version = "0.5.1"
+version = "0.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "clingo" },


### PR DESCRIPTION
What's new in Version 0.6.0:

### backend:
* refactor(!): change solver structure from module import to inheritance (#103)
* feat(!): change the `program` back to `solve`
* feat: remove deepcopy for more compatibility
* fix: pre-generate solver metadata for efficiency
* feat: move all the logging to `noqx.clingo` module
* fix: multiple solver instances are loaded

### frontend:
* feat(!): support client-side loading with the help of `PyScript`
* fix: puzzle parameters are not reset properly
* fix: loading scripts error on deployment
* fix: content error when resetting the board

### solver:
* fix: remove BOM in `pipelink` solver